### PR TITLE
refactor: remove RS485 coexistence handling; simplify protocol logic …

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -286,16 +286,11 @@
 #define RS485_PROBE_BACKOFF_MAX_MS (5 * 60 * 1000) ///< Max backoff for RS485 probe retry
 #define RS485_UART_RX_BUFFER_SIZE 1024 ///< UART RX ring buffer for full 125-register frames
 #define RS485_MIN_REQUEST_GAP_MS 120   ///< Quiet time between serialized RS485 requests
-#define RS485_EXTERNAL_BUSY_HOLD_MS \
-    1100 ///< Bus-busy hold (ms) after an external/foreign frame; raise if dongle frames exceed this
-#define RS485_COEXISTENCE_ENABLED 1 ///< Enable dual-master coexistence backoff/cache mode
-#define RS485_COEXISTENCE_TRIGGER_EVENTS \
-    2 ///< Consecutive contention events before quiet-window backoff
-#define RS485_COEXISTENCE_BACKOFF_MS 8000 ///< Quiet window after detected RS485 contention
-#define RS485_COEXISTENCE_PRESSURE_WINDOW_MS \
-    20000 ///< Prefer fresh cache shortly after any contention event
-#define RS485_COEXISTENCE_CACHE_MAX_AGE_MS \
-    45000 ///< Max cached-data age served proactively while the bus is contested
+#define RS485_FOREIGN_IDLE_TAIL_MS \
+    450 ///< Idle-tail: bus stays "busy" until the line is quiet this long after a foreign frame.
+        ///< Bridges the foreign request->response turnaround so we never transmit into the gap.
+        ///< Sized from measured turnaround on this inverter: typical ~106 ms, outlier ~351 ms;
+        ///< 450 (+50 ms inter-frame = 500 ms coverage) clears the outlier with margin.
 #define COMMAND_DEBOUNCE_MS 10000   ///< Debounce window for reboot/wifi_restart commands
 #define BOOT_FAIL_RESET_THRESHOLD 5 ///< After N failed boots, clear WiFi creds and open portal
 

--- a/src/modules/command_manager.cpp
+++ b/src/modules/command_manager.cpp
@@ -285,26 +285,6 @@ void CommandManager::registerCoreCommands() {
                         msg += "/";
                         msg += String(bridge.get_last_finished_elapsed_ms());
                         msg += "ms";
-                        msg += " coex=";
-#if RS485_COEXISTENCE_ENABLED
-                        msg += String(bridge.get_coexistence_backoff_remaining_ms());
-                        msg += "ms";
-                        msg += " coex_pressure=";
-                        msg += String(bridge.get_coexistence_pressure_remaining_ms());
-                        msg += "ms";
-#else
-                        msg += "off";
-#endif
-                        msg += " coex_events=";
-                        msg += String(bridge.get_coexistence_event_count());
-                        msg += " coex_cache=";
-                        msg += String(bridge.get_coexistence_cache_hits());
-                        msg += " coex_stale=";
-                        msg += String(bridge.get_coexistence_cache_stale_count());
-                        msg += " coex_miss=";
-                        msg += String(bridge.get_coexistence_cache_miss_count());
-                        msg += " coex_seq=";
-                        msg += String(bridge.get_consecutive_contention_events());
 
 #ifdef ENABLE_WEB_DASH
                         {

--- a/src/modules/protocol_bridge.cpp
+++ b/src/modules/protocol_bridge.cpp
@@ -78,172 +78,6 @@ TCPClient* ProtocolBridge::resolve_current_client() {
     return tcp_server_->resolve_client(current_request_.client_handle);
 }
 
-uint32_t ProtocolBridge::get_coexistence_backoff_remaining_ms() const {
-#if !RS485_COEXISTENCE_ENABLED
-    return 0;
-#else
-    const uint32_t now = millis();
-    if ((int32_t) (coexistence_backoff_until_ms_ - now) <= 0) {
-        return 0;
-    }
-    return coexistence_backoff_until_ms_ - now;
-#endif
-}
-
-bool ProtocolBridge::is_coexistence_backoff_active() const {
-#if !RS485_COEXISTENCE_ENABLED
-    return false;
-#else
-    return get_coexistence_backoff_remaining_ms() > 0;
-#endif
-}
-
-uint32_t ProtocolBridge::get_coexistence_pressure_remaining_ms() const {
-#if !RS485_COEXISTENCE_ENABLED
-    return 0;
-#else
-    const uint32_t backoff_ms = get_coexistence_backoff_remaining_ms();
-    if (backoff_ms > 0) {
-        return backoff_ms;
-    }
-
-    if (last_coexistence_event_ms_ == 0) {
-        return 0;
-    }
-
-    const uint32_t elapsed_ms = millis() - last_coexistence_event_ms_;
-    if (elapsed_ms >= RS485_COEXISTENCE_PRESSURE_WINDOW_MS) {
-        return 0;
-    }
-    return RS485_COEXISTENCE_PRESSURE_WINDOW_MS - elapsed_ms;
-#endif
-}
-
-bool ProtocolBridge::is_coexistence_pressure_active() const {
-    return get_coexistence_pressure_remaining_ms() > 0;
-}
-
-bool ProtocolBridge::is_coexistence_error(const String& error) const {
-#if !RS485_COEXISTENCE_ENABLED
-    return false;
-#else
-    return error == "Timeout" || error.indexOf("other master") >= 0 ||
-           error.indexOf("collision") >= 0 || error.indexOf("Invalid response frame") >= 0 ||
-           error.indexOf("No valid frames") >= 0;
-#endif
-}
-
-void ProtocolBridge::note_rs485_contention(const char* reason, bool immediate_backoff) {
-#if !RS485_COEXISTENCE_ENABLED
-    (void) reason;
-    (void) immediate_backoff;
-    return;
-#else
-    last_coexistence_event_ms_ = millis();
-    coexistence_events_++;
-    if (consecutive_contention_events_ < 255) {
-        consecutive_contention_events_++;
-    }
-
-    if (!immediate_backoff && consecutive_contention_events_ < RS485_COEXISTENCE_TRIGGER_EVENTS) {
-        LOGI(TAG, "RS485 contention marker %u/%u: %s", consecutive_contention_events_,
-             RS485_COEXISTENCE_TRIGGER_EVENTS, reason ? reason : "unknown");
-        return;
-    }
-
-    const uint32_t now = millis();
-    const uint32_t until = now + RS485_COEXISTENCE_BACKOFF_MS;
-    const bool was_active = is_coexistence_backoff_active();
-    coexistence_backoff_until_ms_ = until;
-
-    LOGW(TAG, "%scoexistence backoff for %lums after RS485 contention: %s",
-         was_active ? "Extending " : "Entering ", RS485_COEXISTENCE_BACKOFF_MS,
-         reason ? reason : "unknown");
-#endif
-}
-
-void ProtocolBridge::reset_rs485_contention() {
-    if (consecutive_contention_events_ > 0 && !is_coexistence_backoff_active()) {
-        LOGI(TAG, "RS485 contention cleared after successful fresh response");
-    }
-    consecutive_contention_events_ = 0;
-}
-
-bool ProtocolBridge::try_coexistence_backoff_for_current_request(const char* reason) {
-    const uint32_t remaining_ms = get_coexistence_backoff_remaining_ms();
-    if (remaining_ms == 0) {
-        return false;
-    }
-
-    set_current_state(BridgeWorkerState::COEXISTENCE_BACKOFF);
-
-    if (try_coexistence_cache_for_current_request(reason, true)) {
-        return true;
-    }
-
-    LOGW(TAG, "[REQ#%u] Coexistence backoff active (%lums left) but no fresh cache is available",
-         current_request_.id, remaining_ms);
-    send_error_response("RS485 coexistence backoff active");
-    failed_requests_++;
-    finish_current_request(BridgeWorkerState::FAILED);
-    return true;
-}
-
-bool ProtocolBridge::try_coexistence_cache_for_current_request(const char* reason, bool required) {
-#if !RS485_COEXISTENCE_ENABLED
-    (void) reason;
-    (void) required;
-    return false;
-#else
-    if (current_request_.wifi_request.is_write_operation) {
-        return false;
-    }
-
-    ReadCacheKey cache_key{current_request_.wifi_request.function_code,
-                           current_request_.wifi_request.start_register,
-                           current_request_.wifi_request.register_count};
-
-    std::vector<uint8_t> cached_response;
-    uint32_t age_ms = 0;
-    bool found = false;
-    if (!get_cached_response(cache_key, cached_response, RS485_COEXISTENCE_CACHE_MAX_AGE_MS,
-                             &age_ms, &found, true)) {
-        if (found) {
-            coexistence_cache_stale_++;
-            if (required) {
-                LOGW(TAG, "[REQ#%u] Coexistence cache stale for %s (age=%lums > %lums)",
-                     current_request_.id, cache_key.format().c_str(), age_ms,
-                     RS485_COEXISTENCE_CACHE_MAX_AGE_MS);
-            } else {
-                LOGD(TAG, "[REQ#%u] Coexistence cache stale for %s (age=%lums)",
-                     current_request_.id, cache_key.format().c_str(), age_ms);
-            }
-        } else {
-            coexistence_cache_misses_++;
-            if (required) {
-                LOGW(TAG, "[REQ#%u] No coexistence cache entry for %s", current_request_.id,
-                     cache_key.format().c_str());
-            }
-        }
-        return false;
-    }
-
-    set_current_state(BridgeWorkerState::CACHE_FALLBACK);
-    if (!send_response_to_client(cached_response, cached_response.size())) {
-        failed_requests_++;
-        finish_current_request(BridgeWorkerState::FAILED);
-        return true;
-    }
-
-    coexistence_cache_hits_++;
-    successful_requests_++;
-    LOGI(TAG, "[REQ#%u] Served coexistence cache for %s (%s, age=%lums)", current_request_.id,
-         cache_key.format().c_str(), reason ? reason : "coexistence", age_ms);
-    finish_current_request(BridgeWorkerState::CACHE_FALLBACK);
-    return true;
-#endif
-}
-
 void ProtocolBridge::process_wifi_request(const uint8_t* data, size_t length, TCPClient* client) {
     if (!is_ready()) {
         LOGW(TAG, "Bridge not ready (tcp_server=%p, rs485=%p)", tcp_server_, rs485_);
@@ -386,8 +220,6 @@ const char* ProtocolBridge::worker_state_name(BridgeWorkerState state) {
             return "RS485_RETRY";
         case BridgeWorkerState::WAIT_RESPONSE:
             return "WAIT_RESPONSE";
-        case BridgeWorkerState::COEXISTENCE_BACKOFF:
-            return "COEXISTENCE_BACKOFF";
         case BridgeWorkerState::CACHE_FALLBACK:
             return "CACHE_FALLBACK";
         case BridgeWorkerState::RESPOND_TCP:
@@ -487,24 +319,9 @@ void ProtocolBridge::start_current_request() {
 
     set_current_state(BridgeWorkerState::RS485_SEND);
 
-    if (try_coexistence_backoff_for_current_request("coexistence backoff")) {
-        return;
-    }
-
-    if (is_coexistence_pressure_active() &&
-        try_coexistence_cache_for_current_request("recent RS485 contention", false)) {
-        return;
-    }
-
-    if (rs485_) {
-        const uint32_t bus_busy_ms = rs485_->get_bus_busy_remaining_ms();
-        if (bus_busy_ms > 0) {
-            note_rs485_contention("external RS485 traffic detected", true);
-            if (try_coexistence_backoff_for_current_request("external RS485 traffic")) {
-                return;
-            }
-        }
-    }
+    // Carrier sense: if the bus is busy with foreign traffic, the send below
+    // returns false and the request is deferred to the retry loop, which waits
+    // for the line to go idle (jittered). No separate backoff window needed.
 
     LOGD(TAG, "[REQ#%u] RS485 packet: %s", current_request_.id,
          TcpProtocol::format_hex(current_request_.wifi_request.rs485_packet.data(),
@@ -604,25 +421,6 @@ void ProtocolBridge::process_pending_rs485_send() {
 
     const uint32_t now = millis();
     const uint32_t age_ms = now - current_request_.timestamp;
-
-    if (try_coexistence_backoff_for_current_request("coexistence backoff during RS485 retry")) {
-        return;
-    }
-
-    if (is_coexistence_pressure_active() &&
-        try_coexistence_cache_for_current_request("recent RS485 contention during retry", false)) {
-        return;
-    }
-
-    if (rs485_) {
-        const uint32_t bus_busy_ms = rs485_->get_bus_busy_remaining_ms();
-        if (bus_busy_ms > 0) {
-            note_rs485_contention("external RS485 traffic detected during retry", true);
-            if (try_coexistence_backoff_for_current_request("external RS485 traffic")) {
-                return;
-            }
-        }
-    }
 
     if (age_ms >= RS485_SEND_RETRY_WINDOW_MS ||
         current_request_.retry_count >= RS485_SEND_MAX_RETRIES) {
@@ -899,9 +697,9 @@ BridgeWorkerState ProtocolBridge::handle_rs485_success(const ParseResult& rs485_
              current_request_.wifi_request.start_register, expected_count,
              static_cast<uint8_t>(rs485_result.function_code), rs485_result.start_address,
              rs485_result.register_count);
-        note_rs485_contention("response mismatch/not ours", true);
 
-        // Fix #6: on a mismatch (typically dual-master collision), don't hard-fail.
+        // On a mismatch (typically a dual-master collision: the frame on the bus
+        // is not the answer to our request), don't hard-fail.
         // A cached read response is better than an error from HA's perspective.
         if (try_fallback_cache_on_error(rs485_result)) {
             LOGI(TAG, "Mismatch recovered via fallback cache");
@@ -921,7 +719,6 @@ BridgeWorkerState ProtocolBridge::handle_rs485_success(const ParseResult& rs485_
     LOGI(TAG, "[REQ#%u] OK func=0x%02X regs=%d start=%d time=%lums%s", current_request_.id,
          static_cast<uint8_t>(rs485_result.function_code), rs485_result.register_count,
          rs485_result.start_address, elapsed, value_summary);
-    reset_rs485_contention();
 
     if (send_wifi_response(rs485_result)) {
         successful_requests_++;
@@ -937,10 +734,6 @@ BridgeWorkerState ProtocolBridge::handle_rs485_success(const ParseResult& rs485_
 
 BridgeWorkerState ProtocolBridge::handle_rs485_error(const ParseResult& rs485_result,
                                                      unsigned long elapsed) {
-    if (is_coexistence_error(rs485_result.error_message)) {
-        note_rs485_contention(rs485_result.error_message.c_str(), false);
-    }
-
     // ========== TRY FALLBACK CACHE FIRST ==========
     // This is critical for handling collisions/mismatches
     // Even if response is mismatch, cache might have valid data

--- a/src/modules/protocol_bridge.h
+++ b/src/modules/protocol_bridge.h
@@ -90,7 +90,6 @@ enum class BridgeWorkerState : uint8_t {
     RS485_SEND,
     RS485_RETRY,
     WAIT_RESPONSE,
-    COEXISTENCE_BACKOFF,
     CACHE_FALLBACK,
     RESPOND_TCP,
     DONE,
@@ -157,13 +156,6 @@ class ProtocolBridge {
         return worker_state_name(last_terminal_state_);
     }
     uint32_t get_last_finished_elapsed_ms() const { return last_finished_elapsed_ms_; }
-    uint32_t get_coexistence_backoff_remaining_ms() const;
-    uint32_t get_coexistence_pressure_remaining_ms() const;
-    uint32_t get_coexistence_event_count() const { return coexistence_events_; }
-    uint32_t get_coexistence_cache_hits() const { return coexistence_cache_hits_; }
-    uint32_t get_coexistence_cache_stale_count() const { return coexistence_cache_stale_; }
-    uint32_t get_coexistence_cache_miss_count() const { return coexistence_cache_misses_; }
-    uint8_t get_consecutive_contention_events() const { return consecutive_contention_events_; }
 
     // ========== Cache Status Methods ==========
     size_t get_cache_size() const { return fallback_cache_.size(); }
@@ -204,13 +196,6 @@ class ProtocolBridge {
     void set_current_state(BridgeWorkerState state);
     static const char* worker_state_name(BridgeWorkerState state);
     static bool validate_response_match(const ParseResult& result, const TcpParseResult& request);
-    bool is_coexistence_backoff_active() const;
-    bool is_coexistence_pressure_active() const;
-    void note_rs485_contention(const char* reason, bool immediate_backoff = false);
-    void reset_rs485_contention();
-    bool is_coexistence_error(const String& error) const;
-    bool try_coexistence_backoff_for_current_request(const char* reason);
-    bool try_coexistence_cache_for_current_request(const char* reason, bool required);
     bool send_wifi_response(const ParseResult& rs485_result);
     void send_error_response(const String& error);
     bool send_gateway_target_failed_response(const String& reason);
@@ -257,15 +242,6 @@ class ProtocolBridge {
     uint32_t last_send_attempt_time_ = 0;
     uint32_t current_retry_delay_ms_ = RS485_SEND_RETRY_DELAY_MS;
     bool paused_ = false;
-
-    // ========== Dual-dongle coexistence ==========
-    uint32_t coexistence_backoff_until_ms_ = 0;
-    uint32_t last_coexistence_event_ms_ = 0;
-    uint32_t coexistence_events_ = 0;
-    uint32_t coexistence_cache_hits_ = 0;
-    uint32_t coexistence_cache_stale_ = 0;
-    uint32_t coexistence_cache_misses_ = 0;
-    uint8_t consecutive_contention_events_ = 0;
 
     // ========== Fallback Cache ==========
     std::map<ReadCacheKey, ReadCacheEntry> fallback_cache_;

--- a/src/modules/rs485_manager.cpp
+++ b/src/modules/rs485_manager.cpp
@@ -45,15 +45,18 @@ const char* RS485Manager::function_code_to_string(ModbusFunctionCode func) {
 }
 
 bool RS485Manager::is_bus_busy() const {
-    return millis() < bus_busy_until_ms_;
-}
-
-uint32_t RS485Manager::get_bus_busy_remaining_ms() const {
-    const uint32_t now = millis();
-    if ((int32_t) (bus_busy_until_ms_ - now) <= 0) {
-        return 0;
-    }
-    return bus_busy_until_ms_ - now;
+    // (1) Idle-tail timer: refreshed on every foreign frame. Keeps the bus "busy"
+    //     until the line has been quiet for RS485_FOREIGN_IDLE_TAIL_MS, which
+    //     bridges the foreign request->response turnaround so we never transmit
+    //     into the gap and clobber the inverter's reply to the other master.
+    if ((int32_t) (bus_busy_until_ms_ - millis()) > 0)
+        return true;
+    // (2) Instant carrier sense: bytes are arriving on the line right now (a frame
+    //     is mid-assembly). Closes the window between the first foreign byte and
+    //     the moment the frame is classified (one inter-frame delay later).
+    if (!rx_buffer_.empty() && (millis() - last_rx_time_) <= MODBUS_INTER_FRAME_DELAY_MS)
+        return true;
+    return false;
 }
 
 void RS485Manager::begin(HardwareSerial& serial, int8_t tx_pin, int8_t rx_pin, int8_t de_pin,
@@ -108,6 +111,13 @@ void RS485Manager::request_inverter_serial_probe() {
         return;
     }
 
+    // Carrier sense: never probe onto a bus that is busy with foreign traffic.
+    // (loop() no longer guards this, so the gate must live here.)
+    if (is_bus_busy()) {
+        LOGD(TAG, "Skipping inverter serial probe: bus busy with foreign traffic");
+        return;
+    }
+
     if (millis() < next_serial_probe_ms_)
         return;
 
@@ -139,14 +149,11 @@ void RS485Manager::loop() {
     if (!initialized_)
         return;
 
-    // ========== RS485_BUS_BUSY CHECK ==========
-    // If bus is busy (external traffic detected), don't process anything
-    if (is_bus_busy()) {
-        LOGD(TAG, "RS485_BUS_BUSY: Skipping processing (%lums remaining)",
-             bus_busy_until_ms_ - millis());
-        return;
-    }
-    // ========== END BUS BUSY CHECK ==========
+    // Always listen: drain + classify RX every loop, even while the bus is busy
+    // with foreign traffic, so the "ear" stays continuous and is_bus_busy() tracks
+    // the real line state. Transmitting is still gated by is_bus_busy() inside
+    // send_read_request()/send_write_request() and the probe, so we never transmit
+    // on a busy bus.
 
     // Auto-probe when link is down
     if (!inverter_link_ok_ && !serial_probe_pending_ && !waiting_response_ &&
@@ -314,7 +321,7 @@ bool RS485Manager::should_ignore_packet(const std::vector<uint8_t>& data) {
     if (data.empty())
         return true;
 
-    // Ignore requests from another master (address 0x00)
+    // Foreign request from another master (address 0x00): not ours.
     if (InverterProtocol::is_request(data.data(), data.size())) {
         if (data.size() >= 3) {
             uint8_t addr = data[0];
@@ -323,17 +330,20 @@ bool RS485Manager::should_ignore_packet(const std::vector<uint8_t>& data) {
                  func, data.size(),
                  InverterProtocol::format_hex(data.data(), min(data.size(), (size_t) 18)).c_str());
             external_requests_detected_++;
-
-            bus_busy_until_ms_ = millis() + RS485_EXTERNAL_BUSY_HOLD_MS;
-            LOGI(TAG, "⚠️ RS485_BUS_BUSY: Pausing");
         }
+        // Foreign frame seen: refresh the idle-tail so the bus stays busy until the
+        // line is quiet for RS485_FOREIGN_IDLE_TAIL_MS (covers the upcoming reply).
+        bus_busy_until_ms_ = millis() + RS485_FOREIGN_IDLE_TAIL_MS;
         ignored_packets_++;
         return true;
     }
 
-    // Ignore if we're not waiting for a response
+    // Not a request and we're not awaiting our own response: this is a cold foreign
+    // response (the inverter answering the other master). Still foreign bus
+    // activity, so refresh the idle-tail too.
     if (!waiting_response_) {
-        LOGD(TAG, "Ignoring packet while not waiting for response");
+        LOGD(TAG, "Ignoring foreign frame while not awaiting our response");
+        bus_busy_until_ms_ = millis() + RS485_FOREIGN_IDLE_TAIL_MS;
         ignored_packets_++;
         return true;
     }

--- a/src/modules/rs485_manager.h
+++ b/src/modules/rs485_manager.h
@@ -64,7 +64,6 @@ class RS485Manager {
     uint32_t get_timeout_count() const { return timeout_count_; }
     uint32_t get_ignored_packets() const { return ignored_packets_; }
     uint32_t get_external_requests_detected() const { return external_requests_detected_; }
-    uint32_t get_bus_busy_remaining_ms() const;
 
   private:
     RS485Manager() = default;


### PR DESCRIPTION
## Summary

Replaces the accumulated "dual-master coexistence" machinery with a single,
inspectable carrier-sense model. OpenLux shares one RS485 bus with the official
Luxpower dongle (two independent masters on the SNA-12K HDMI port); this PR makes
OpenLux listen to the bus continuously and stay out of the dongle's way, while a
single fallback cache absorbs the collisions that cannot be prevented.

Net change: **-247 lines** (290 deletions / 43 insertions), no new config knobs,
one removed.

## Motivation

The previous coexistence code had grown into many overlapping mechanisms (an 8 s
backoff window, a 20 s "pressure" window, a second cache path, contention
counters, a dedicated FSM state). They added state that was hard to inspect
without improving the outcome, and one gate was effectively shadowed by an
older reactive check. The bus-busy hold was also a blind fixed timer that only
reacted to foreign *requests* and went deaf for its whole duration.

## What changed

### Removed
- 8 s coexistence backoff (`note_rs485_contention`, `try_coexistence_backoff_*`)
- 20 s pressure window (`is_coexistence_pressure_active`)
- Duplicate "coexistence cache" path and its separate stats
- Consecutive-contention counter and `COEXISTENCE_BACKOFF` FSM state
- `is_coexistence_error` classifier and all `#if RS485_COEXISTENCE_ENABLED` guards
- `coex*` fields from the status string
- Dead `get_bus_busy_remaining_ms()` (no remaining callers)
- Config macros: `RS485_COEXISTENCE_ENABLED`, `_BACKOFF_MS`,
  `_PRESSURE_WINDOW_MS`, `_CACHE_MAX_AGE_MS`, `_TRIGGER_EVENTS`

### Added / changed (the "always-on ear")
- `loop()` now drains and classifies RX **every iteration**, even while the bus
  is busy with foreign traffic (continuous listening). Transmits remain gated by
  `is_bus_busy()` inside `send_read_request()`/`send_write_request()`/the probe.
- `is_bus_busy()` is now a dual gate: an **idle-tail timer** (refreshed on every
  foreign frame) plus **instant carrier sense** (bytes mid-assembly on the wire),
  which closes the window before a frame is classified.
- `should_ignore_packet()` refreshes the idle-tail on every foreign frame
  (foreign request *and* cold foreign response), not only on requests.
- `request_inverter_serial_probe()` now carries its own `is_bus_busy()` gate
  (previously it relied on the removed `loop()` early-return).
- Renamed `RS485_EXTERNAL_BUSY_HOLD_MS` (1100, fixed/blind) →
  `RS485_FOREIGN_IDLE_TAIL_MS` (450). The value was sized from the measured
  request→response turnaround of the official dongle on this inverter
  (~106 ms typical, ~351 ms outlier); 450 + 50 ms inter-frame = 500 ms coverage.
- Wrap-safe `millis()` comparison in `is_bus_busy()`.

### Kept (unchanged behavior)
- Single fallback cache (45 s max age) — populated on every successful read.
- Decode-match (`validate_response_match`): a response that is not ours →
  fallback cache.
- Jittered send-retry that waits for the line to go idle.
- Reads fail safe (serve cache); **writes fail loud** (never cached).
- Pause/resume.

## Behavior & validation

Flashed to the live device and observed for ~1 h against the active dongle:
- Carrier sense engages (worker defers to the jittered retry while the bus is
  busy, then completes with fresh data).
- ERR rate dropped (~0.32% → ~0.22%), timeouts went to 0, drops stayed at 0.
- Home Assistant unaffected: live sensors fresh (~10 s), no errors surfaced.

The residual errors are type-B collisions (the dongle starts transmitting while
OpenLux is mid-transaction). These are physically irreducible by one-sided
carrier sense and are absorbed by the fallback cache.

## Breaking changes (config)

The `RS485_COEXISTENCE_*` macros were removed. Any `config.local.h` that
overrides them should drop those lines. `RS485_EXTERNAL_BUSY_HOLD_MS` was
renamed to `RS485_FOREIGN_IDLE_TAIL_MS`.

## Limitations

- Collisions cannot be fully eliminated on a shared bus with an uncooperative
  master (type-B). They are absorbed by the cache, not prevented.
- Half-duplex: OpenLux is deaf during its own transmit.
- Electrical quality (120 Ω termination, bias, A/B polarity) still matters.